### PR TITLE
Fixed example

### DIFF
--- a/example/febio-cube/febio-config.json
+++ b/example/febio-cube/febio-config.json
@@ -5,11 +5,8 @@
             "config_file_name": "../precice-config.xml",
             "read_mesh_name": "FEBioMesh",
             "read_data_name": [
-        {"type": "variable", "class_type": "materialPoint", "febio_class_name": "FESolutesMaterialPoint", "name": "m_ca", "mapping_name": "P_ext", "febio_type": "vector<double>", "precice_type": "scalar"}
+        {"type": "variable", "class_type": "materialPoint", "febio_class_name": "FESolutesMaterialPoint", "name": "m_psi", "mapping_name": "P_ext", "febio_type": "double", "precice_type": "scalar"}
 			],
-            "write_mesh_name": "FEBioMesh",
-            "write_data_name": [
-        {"type": "variable", "class_type": "materialPoint", "febio_class_name": "FESolutesMaterialPoint", "name": "m_ca", "mapping_name": "P_ext", "febio_type": "vector<double>", "precice_type": "scalar"}
-		     ]
+            "write_mesh_name": "FEBioMesh"
     }
   }

--- a/example/febio-cube/run.sh
+++ b/example/febio-cube/run.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-~/FEBio/cbuild/bin/febio4 test.feb
+mpirun -n 1 ~/FEBioStudio/bin/febio4 test.feb

--- a/example/generator_2d/generator_2d.py
+++ b/example/generator_2d/generator_2d.py
@@ -37,7 +37,7 @@ while interface.is_coupling_ongoing():
     dt = np.minimum(dt, precice_dt)
 
     print("Generating data")
-    write_data.fill(0.1)  # Change this value to change which constant data is written to preCICE
+    write_data.fill(t*100)  # Change this value to change which constant data is written to preCICE
 
     interface.write_block_scalar_data(data_id, vertex_ids, write_data)
 

--- a/example/precice-config.xml
+++ b/example/precice-config.xml
@@ -32,7 +32,7 @@
         to="FEBioMesh"
         constraint="consistent" />
       <read-data name="P_ext" mesh="FEBioMesh"/>
-      <export:vtk directory="output" every-n-time-windows="20"/>
+      <export:vtk directory="output" every-n-time-windows="1"/>
     </participant>
 
     <m2n:sockets from="Generator" to="FEBio" exchange-directory=".."/>
@@ -40,7 +40,7 @@
     <coupling-scheme:serial-explicit>
       <participants first="Generator" second="FEBio" />
       <time-window-size value="0.01" />
-      <max-time value="0.3" />
+      <max-time value="1.0" />
       <exchange data="P_ext" mesh="Generator-Mesh" from="Generator" to="FEBio"/>
     </coupling-scheme:serial-explicit>
   </solver-interface>


### PR DESCRIPTION
Fixed the configuration for the coupling example.
Changed type of coupled variable to double because the conversion vector<double> -> scalar is not implemented in the adapter.
Removed the write_data_name field because precice cannot read and write to the same mesh.
The write_mesh_name has to be left in the configuration, or the adapter throws a std::exception after reading the json file. 
Changed the python generator to incrementally increase the coupled value.